### PR TITLE
Add Neo NB to skip list, and alphabetize

### DIFF
--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/parse.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/parse.py
@@ -6,16 +6,18 @@ from github import Github
 from notebooks.git import Git
 
 SKIP_LIST = {
-    "ground_truth_labeling_jobs",
     "aws_marketplace",
-    "label_data",
     "contrib",
-    "sagemaker-fundamentals",
     "end_to_end",
-    "use-cases",
-    "step-functions-data-science-sdk",
-    "prep_data",
+    "ground_truth_labeling_jobs",
     "ingest_data",
+    "label_data",
+    "prep_data",
+    "sagemaker-fundamentals",
+    "sagemaker_edge_manager/sagemaker_edge_example/sagemaker_edge_example.ipynb",
+    "sagemaker_neo_compilation_jobs/gluoncv_yolo/gluoncv_yolo_neo.ipynb",
+    "step-functions-data-science-sdk",
+    "use-cases",
 }
 
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Re: https://github.com/aws/amazon-sagemaker-examples/pull/2613
These notebooks use EC2 and Neo model compilation that won't pass CI.
Edge manager directory is already added. I added the full path to `sagemaker_neo_compilation_jobs/gluoncv_yolo/gluoncv_yolo_neo.ipynb`.

I also alphabetized the skip list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
