### PR TITLE
Regenerate symlinks after source downloaded by CodePipeline

### DIFF
--- a/cdk-project/lib/buildspecs.ts
+++ b/cdk-project/lib/buildspecs.ts
@@ -68,7 +68,10 @@ export function createFullRepoScanBuildSpec(): codebuild.BuildSpec {
         },
         phases: {
             build: {
-                commands: ["run-all-notebooks --instance $INSTANCE_TYPE"],
+                commands: [
+                    `find reinforcement_learning/*/common -maxdepth 0 -type f | xargs -I R1 sh -c "cat R1 | xargs -I R2 ln -sf R2 R1"`,
+                    `run-all-notebooks --instance $INSTANCE_TYPE`,
+                ],
             },
         },
         artifacts: {


### PR DESCRIPTION
*Description of changes:*
For nightly builds, the source repo is downloaded by CodePipeline.
This has a limitation of not preserving the symlinks
https://forums.aws.amazon.com/thread.jspa?threadID=245780. This
causes the imports to be broken in a lot of notebooks. The workaround
mentioned in the post above is to regenerate the symlinks after download.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
