### PR TITLE
Updates to allow list and make build href/URL friendly

### DIFF
--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/dictionary.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/dictionary.py
@@ -446,6 +446,16 @@ allow_list = {
     "Explainability",
     "libsvm",
     "protobuf",
+    "MNIST",
+    "DeepAR",
+    "RegisterModelStep",
+    "TuningStep",
+    "ModelName",
+    "ModelPackageName",
+    "ModelPackageGroupName",
+    "CreateModel",
+    "HPO",
+    "featurized"
 }
 
 rules_to_ignore = {

--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/lint.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/lint.py
@@ -32,6 +32,9 @@ def check_grammar(notebook):
             code_substituted_line = re.sub(
                 "(`)\1{2,}[^`]*(`)\1{2,}|`[^`]*`", "[code]", stripped_line
             )
+            #Strip down any anchor tags from the text before proceeding
+            code_substituted_line = re.sub('<a.*?>|</a>', '', code_substituted_line)
+
             matches = tool.check(code_substituted_line)
             report.extend(matches)
 

--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/lint.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/lint.py
@@ -32,8 +32,9 @@ def check_grammar(notebook):
             code_substituted_line = re.sub(
                 "(`)\1{2,}[^`]*(`)\1{2,}|`[^`]*`", "[code]", stripped_line
             )
-            #Strip down any anchor tags from the text before proceeding
+            # Strip down any anchor tags or URL markdown from the text before proceeding
             code_substituted_line = re.sub('<a.*?>|</a>', '', code_substituted_line)
+            code_substituted_line = re.sub(r'\[(.*?)\]\((.*?)\)',r'\1',code_substituted_line)
 
             matches = tool.check(code_substituted_line)
             report.extend(matches)


### PR DESCRIPTION
*Issue #, if available:* https://issues.amazon.com/issues/MD-3506

*Description of changes:*
- Add checks to test only the text inside anchor tags or URL markdown, but not fail on the markdown or tag itself
- Add more words to allow list

Tested on previously failing PRs which run successfully now:
- https://github.com/aws/amazon-sagemaker-examples/pull/2818
- Feature Store and Ground Truth: https://github.com/aws/amazon-sagemaker-examples/pull/2822
- Securely storing images into Feature Store: https://github.com/aws/amazon-sagemaker-examples/pull/2819


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
