### PR TITLE
Add Cal Housing Pipelines/Lambda NB to skip list

### DIFF
--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/parse.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/parse.py
@@ -16,6 +16,7 @@ SKIP_LIST = {
     "prep_data",
     "sagemaker-fundamentals",
     "sagemaker-pipelines/tabular/lambda-step/sagemaker-pipelines-lambda-step.ipynb",
+    "sagemaker-pipelines/tabular/tensorflow2-california-housing-sagemaker-pipelines-deploy-endpoint/tensorflow2-california-housing-sagemaker-pipelines-deploy-endpoint.ipynb",
     "sagemaker_edge_manager",
     "sagemaker_neo_compilation_jobs/gluoncv_yolo/gluoncv_yolo_neo.ipynb",
     "step-functions-data-science-sdk",


### PR DESCRIPTION
*Issue #, if available:* n/a

PR: https://github.com/aws/amazon-sagemaker-examples/pull/2865 

*Description of changes:* Add Cal Housing Pipelines/Lambda NB to skip list. It creates a Lambda function and IAM execution role which will not pass CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
