### PR TITLE
Expose base env to jupyter for picking up refreshed packages

### DIFF
--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/describe_notebook_jobs.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/describe_notebook_jobs.py
@@ -48,6 +48,7 @@ def main():
     statuses = []
     errors = []
     dates = []
+    error_details= []
 
     sagemaker = session.client("sagemaker")
     for index, row in dataframe.iterrows():
@@ -82,7 +83,9 @@ def main():
                 lines = error.splitlines()
                 for line in reversed(lines):
                     if any(error_type in line for error_type in valid_error_types):
-                        error = line.split(":", 1)[0]
+                        error_parsed = line.split(":", 1)
+                        error = error_parsed[0]
+                        detail = error_parsed[1]
                         found_error_type = True
                         break
                 if not found_error_type:
@@ -96,6 +99,7 @@ def main():
         statuses.append(status)
         errors.append(error)
         dates.append(date)
+        error_details.append(detail)
 
         print(job_name)
         time.sleep(1)
@@ -110,6 +114,7 @@ def main():
             "runtime": runtimes,
             "status": statuses,
             "error": errors,
+            "error_detail": error_details
         }
     )
 

--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/run.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/run.py
@@ -242,7 +242,6 @@ def execute_notebook(
 
     api_args["Environment"]["PAPERMILL_INPUT"] = local_input
     api_args["Environment"]["PAPERMILL_OUTPUT"] = local_output + result
-    api_args["Environment"]["PAPERMILL_kernel"] = local_output + result
     if os.environ.get("AWS_DEFAULT_REGION") != None:
         api_args["Environment"]["AWS_DEFAULT_REGION"] = os.environ["AWS_DEFAULT_REGION"]
     api_args["Environment"]["PAPERMILL_PARAMS"] = json.dumps(parameters)

--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/run.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/run.py
@@ -242,6 +242,7 @@ def execute_notebook(
 
     api_args["Environment"]["PAPERMILL_INPUT"] = local_input
     api_args["Environment"]["PAPERMILL_OUTPUT"] = local_output + result
+    api_args["Environment"]["PAPERMILL_kernel"] = local_output + result
     if os.environ.get("AWS_DEFAULT_REGION") != None:
         api_args["Environment"]["AWS_DEFAULT_REGION"] = os.environ["AWS_DEFAULT_REGION"]
     api_args["Environment"]["PAPERMILL_PARAMS"] = json.dumps(parameters)

--- a/cdk-project/lib/images/processing-image/execute.py
+++ b/cdk-project/lib/images/processing-image/execute.py
@@ -65,6 +65,7 @@ def run_notebook():
         if not kernel:
             nb_kernel = kernel_for(notebook_file)
             avail_kernels = available_kernels()
+            print("available kernels are ", avail_kernels)
             if nb_kernel is None or nb_kernel not in avail_kernels:
                 kernel = avail_kernels[0]
             else:

--- a/cdk-project/lib/images/processing-image/execute.py
+++ b/cdk-project/lib/images/processing-image/execute.py
@@ -65,10 +65,13 @@ def run_notebook():
         if not kernel:
             nb_kernel = kernel_for(notebook_file)
             avail_kernels = available_kernels()
-            print("available kernels are ", avail_kernels)
+            print("The kernel found in the notebook metadata is: ", nb_kernel)
+            print("The kernels available to execute within jupyter are kernels are: ", ','.join(avail_kernels))
             if nb_kernel is None or nb_kernel not in avail_kernels:
+                print("No default notebook kernel found or it is not available in the execution environment, picking from available kernels")
                 kernel = avail_kernels[0]
             else:
+                print("Using notebook provided kernel: ", nb_kernel)
                 kernel = nb_kernel
 
         print(

--- a/cdk-project/lib/images/processing-image/run_notebook
+++ b/cdk-project/lib/images/processing-image/run_notebook
@@ -1,4 +1,7 @@
 #!/bin/bash
 
 #python3 -u /opt/program/execute.py 2>&1 | stdbuf -o0 tr '\r' '\n'
+#Expose default python execution environment to jupyter
+python3 -m ipykernel install --user --name base-env
+
 python3 /opt/program/execute.py


### PR DESCRIPTION
*Issue #, if available:*
https://tiny.amazon.com/8me0vchy

*Description of changes:*

The branch name is a misnomer. We are exposing the default environment provided by this image to jupyter wherever available, this allows the env with updated packages to be ingested by jupyter's kernelspec instead of using the default python3 kernel for everything. Also adds the error message received during exeecution to the csv for better debugging, right now only the error type is exposed for Athena and this is not enough to get a sense for what's wrong and what failures change on a daily basis.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
