### PR TITLE
Add RNNT FSx notebook to CI skip list

### DIFF
--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/parse.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/parse.py
@@ -21,6 +21,7 @@ SKIP_LIST = {
     "sagemaker_edge_manager",
     "sagemaker_neo_compilation_jobs/gluoncv_yolo/gluoncv_yolo_neo.ipynb",
     "step-functions-data-science-sdk",
+    "training/distributed_training/pytorch/data_parallel/rnnt/RNNT_notebook.ipynb",
     "use-cases",
 }
 


### PR DESCRIPTION
*Issue #, if available:* PR: https://github.com/aws/amazon-sagemaker-examples/pull/2875

Link to future notebook: https://github.com/aws/amazon-sagemaker-examples/blob/master/training/distributed_training/pytorch/data_parallel/rnnt/RNNT_notebook.ipynb

*Description of changes:* Add notebook to skip list which uses FSx file system, which requires a VPC and subnet and is not supported by CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
