### PR TITLE
Skip filesystem notebooks by default (FSx, EFS)

### DIFF
--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/run_all_notebooks.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/run_all_notebooks.py
@@ -22,9 +22,9 @@ def parse_args(args):
         required=False,
     )
     parser.add_argument(
-        "--skip-fsx",
+        "--skip-filesystem",
         default=True,
-        help="Skip notebooks that use FSx file system",
+        help="Skip notebooks that use FSx and EFS file systems",
         type=bool,
         required=False,
     )
@@ -69,8 +69,8 @@ def main():
             notebook, ["docker ", 'instance_type = "local"', "docker-compose ", "Docker "]
         ):
             job_name = None
-        elif args.skip_fsx and parse.contains_code(
-            notebook, ['"FSxLustre"']
+        elif args.skip_filesystem and parse.contains_code(
+            notebook, ['"FSxLustre"', "'FSxLustre'", '"EFS"', "'EFS'"]
         ):
             job_name = None
         elif parse.skip(notebook):

--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/run_all_notebooks.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/run_all_notebooks.py
@@ -21,6 +21,13 @@ def parse_args(args):
         type=bool,
         required=False,
     )
+    parser.add_argument(
+        "--skip-fsx",
+        default=True,
+        help="Skip notebooks that use FSx file system",
+        type=bool,
+        required=False,
+    )
 
     parsed = parser.parse_args(args)
 
@@ -60,6 +67,10 @@ def main():
     for notebook in notebook_names:
         if args.skip_docker and parse.contains_code(
             notebook, ["docker ", 'instance_type = "local"', "docker-compose ", "Docker "]
+        ):
+            job_name = None
+        elif args.skip_fsx and parse.contains_code(
+            notebook, ['"FSxLustre"']
         ):
             job_name = None
         elif parse.skip(notebook):

--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/run_pr_notebooks.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/run_pr_notebooks.py
@@ -28,9 +28,9 @@ def parse_args(args):
         required=False,
     )
     parser.add_argument(
-        "--skip-fsx",
+        "--skip-filesystem",
         default=True,
-        help="Skip notebooks that use FSx file system",
+        help="Skip notebooks that use FSx and EFS file systems",
         type=bool,
         required=False,
     )

--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/run_pr_notebooks.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/run_pr_notebooks.py
@@ -27,6 +27,13 @@ def parse_args(args):
         type=bool,
         required=False,
     )
+    parser.add_argument(
+        "--skip-fsx",
+        default=True,
+        help="Skip notebooks that use FSx file system",
+        type=bool,
+        required=False,
+    )
 
     parsed = parser.parse_args(args)
     if not parsed.pr:


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Add a default skip of EFS and FSx notebooks, similar to the Docker and local mode skipping. CI fails on file system notebooks because it requires configuration of a VPC and subnet. 

Links to sample affected notebook for reference: 

FSX: https://github.com/aws/amazon-sagemaker-examples/blob/master/training/distributed_training/tensorflow/data_parallel/bert/tensorflow2_smdataparallel_bert_demo.ipynb

EFS: https://github.com/aws/amazon-sagemaker-examples/blob/master/advanced_functionality/distributed_tensorflow_mask_rcnn/mask-rcnn-efs.ipynb

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
