### PR TITLE
Add local-mode skip case

### DIFF
--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/run_all_notebooks.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/run_all_notebooks.py
@@ -66,7 +66,7 @@ def main():
     instance_type = args.instance or "ml.m5.xlarge"
     for notebook in notebook_names:
         if args.skip_docker and parse.contains_code(
-            notebook, ["docker ", 'instance_type = "local"', "docker-compose ", "Docker "]
+            notebook, ["docker ", 'instance_type = "local"', 'instance_type="local"', "docker-compose ", "Docker "]
         ):
             job_name = None
         elif args.skip_filesystem and parse.contains_code(

--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/run_pr_notebooks.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/cli/run_pr_notebooks.py
@@ -51,7 +51,7 @@ def main():
     instance_type = args.instance or "ml.m5.xlarge"
     for notebook in parse.pr_notebook_filenames(args.pr):
         if args.skip_docker and parse.contains_code(
-            notebook, ["docker ", 'instance_type = "local"']
+            notebook, ["docker ", 'instance_type = "local"', 'instance_type="local"', "docker-compose ", "Docker "]
         ):
             job_name = None
         elif parse.skip(notebook):


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Sometimes instance_type is set to "local" without spaces, so include both variations in strings to skip notebooks due to use of local mode. `'instance_type = "local"'`, `'instance_type="local"'`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
