### PR TITLE
Add stagger prior to notebook execution

### DIFF
--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/parse.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/parse.py
@@ -180,8 +180,7 @@ def contains_code(notebook, snippets):
         bool: Whether any of the code snippets exist in the notebook's code cells.
 
     """
-    cells = all_cells(notebook)
-    source = [cell["source"] for cell in cells]
+    source = code_cells(notebook)
 
     for cell_source in source:
         for line in cell_source:

--- a/cdk-project/lib/images/processing-image/execute.py
+++ b/cdk-project/lib/images/processing-image/execute.py
@@ -21,7 +21,8 @@ import sys
 import traceback
 from urllib.parse import urlparse
 from urllib.request import urlopen
-
+from random import randint
+from time import sleep
 import boto3
 import botocore
 import jupyter_client.kernelspec as kernelspec
@@ -40,6 +41,10 @@ def run_notebook():
 
         notebook_dir = os.path.dirname(notebook)
         notebook_file = os.path.basename(notebook)
+
+        pause = randint(5,10)
+        print("Waiting {} seconds....".format(pause))
+        sleep(pause)
 
         # If the user specified notebook path in S3, run with that path.
         if notebook.startswith("s3://"):

--- a/cdk-project/lib/images/processing-image/execute.py
+++ b/cdk-project/lib/images/processing-image/execute.py
@@ -42,7 +42,7 @@ def run_notebook():
         notebook_dir = os.path.dirname(notebook)
         notebook_file = os.path.basename(notebook)
 
-        pause = randint(5,10)
+        pause = randint(1,10)
         print("Waiting {} seconds....".format(pause))
         sleep(pause)
 

--- a/cdk-project/lib/project-stack.ts
+++ b/cdk-project/lib/project-stack.ts
@@ -291,7 +291,7 @@ export class ProjectStack extends cdk.Stack {
                 actionName: "WaitAction",
                 stateMachine: new stepfunctions.StateMachine(this, "WaitStateMachine", {
                     definition: new stepfunctions.Wait(this, "WaitForProcessingJobs", {
-                        time: stepfunctions.WaitTime.duration(cdk.Duration.hours(2)),
+                        time: stepfunctions.WaitTime.duration(cdk.Duration.minutes(200)),
                     }),
                 }),
             }),


### PR DESCRIPTION
*Issue #, if available:*
https://tiny.amazon.com/zhg1iuuf

*Description of changes:*
Adds a random stagger between 5 and 10 seconds prior to start of notebook execution. Attempt to separate out calls to training APIs which get frequently throttled. Also adjusts repo scan build time accordingly to cater for the upper bound of time added by this wait across 254 runnable notebooks with a buffer

Tested uptil resource capacity in sandbox account where it ran prior throttled notebooks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
