### PR TITLE
Add Feature Store KMS notebook to skip list

### DIFF
--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/parse.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/parse.py
@@ -18,6 +18,7 @@ SKIP_LIST = {
     "async-inference",
     "patterns/ml_gateway/ml-gateway.ipynb",
     "reinforcement_learning/bandits_statlog_vw_customEnv/bandits_statlog_vw_customEnv.ipynb",
+    "sagemaker-featurestore/feature_store_kms_key_encryption.ipynb",
     "sagemaker-fundamentals",
     "sagemaker-pipelines/tabular/lambda-step/sagemaker-pipelines-lambda-step.ipynb",
     "sagemaker-pipelines/tabular/tensorflow2-california-housing-sagemaker-pipelines-deploy-endpoint/tensorflow2-california-housing-sagemaker-pipelines-deploy-endpoint.ipynb",


### PR DESCRIPTION
*Issue #, if available:* n/a

Related PR: https://github.com/aws/amazon-sagemaker-examples/pull/2942

Link to notebook: https://github.com/aws/amazon-sagemaker-examples/blob/master/sagemaker-featurestore/feature_store_kms_key_encryption.ipynb

*Description of changes:* Add Feature Store KMS notebook to skip list since it requires KMS permissions which CI doesn't have.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
