### PR TITLE
Skip Ray gameserver notebook

### DIFF
--- a/cdk-project/lib/images/codebuild-image/python/src/notebooks/parse.py
+++ b/cdk-project/lib/images/codebuild-image/python/src/notebooks/parse.py
@@ -23,6 +23,7 @@ SKIP_LIST = {
     "async-inference",
     "patterns/ml_gateway/ml-gateway.ipynb",
     "reinforcement_learning/bandits_statlog_vw_customEnv/bandits_statlog_vw_customEnv.ipynb",
+    "reinforcement_learning/rl_game_server_autopilot/sagemaker/rl_gamerserver_ray.ipynb",
     "reinforcement_learning/rl_roboschool_ray/rl_roboschool_ray_automatic_model_tuning.ipynb",
     "sagemaker-featurestore/feature_store_client_side_encryption.ipynb",
     "sagemaker-featurestore/feature_store_kms_key_encryption.ipynb",


### PR DESCRIPTION
*Issue #, if available:* n/a

Related PR: https://github.com/aws/amazon-sagemaker-examples/pull/2992

Link to notebook: https://github.com/aws/amazon-sagemaker-examples/blob/master/reinforcement_learning/rl_game_server_autopilot/sagemaker/rl_gamerserver_ray.ipynb

*Description of changes:* Skip testing of Ray gameserver notebook. The notebook takes 8 hours to train. Has been successfully run manually.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
